### PR TITLE
Feat/#9: rookie-app HPA 리소스 및 적용 가이드 추가

### DIFF
--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: rookie-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: rookie-app
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #9 

## 작업 내용
- `hpa.yaml` 리소스 추가
- `rookie-app` Deployment 대상 HPA 설정
- 최소/최대 Pod 수 설정
- 평균 CPU 사용률 50% 기준 설정
- HPA 적용 및 확인 명령어 정리
- HPA 동작 원리에 대한 주의사항 문서화

## 변경 사항
### 추가
- `hpa.yaml`
- HPA 적용/확인 절차 문서 내용

### 반영된 설정
- `minReplicas: 1`
- `maxReplicas: 5`
- `averageUtilization: 50`

## 확인 방법
```bash
kubectl apply -f hpa.yaml
kubectl get hpa