### PR TITLE
Feat/#11: HPA 테스트용 CPU 부하 API 추가

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,3 +13,16 @@ def hello():
 def slow():
     time.sleep(2)
     return {"message": "slow"}
+
+
+@app.get("/cpu")
+def cpu_load():
+    total = 0
+
+    for i in range(30_000_000):
+        total += i * i
+
+    return {
+        "message": "cpu load completed",
+        "result": total,
+    }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #11 

## 작업 내용
- HPA 부하 테스트를 위한 `/cpu` 엔드포인트 추가
- 기존 `/slow` 엔드포인트는 응답 지연 테스트용으로 유지
- `/cpu` 엔드포인트에서 반복 연산을 수행하여 실제 CPU 사용률을 증가시키도록 구성

## 작업 배경

기존 `/slow` 엔드포인트는 `time.sleep()` 기반이기 때문에 요청 처리 시간은 길어지지만 CPU 사용률은 크게 증가하지 않았다.

HPA는 요청 수가 아니라 CPU 사용률을 기준으로 동작하므로, Pod 자동 확장 테스트를 위해 CPU 사용량을 높일 수 있는 엔드포인트가 필요했다.

## 확인 방법
```bash
while true; do curl http://localhost:30007/cpu; done